### PR TITLE
Fix mobile logo navbar overlap and scroll positioning

### DIFF
--- a/components/hero.tsx
+++ b/components/hero.tsx
@@ -76,7 +76,7 @@ export function Hero() {
               <div className="mt-6 flex flex-col sm:flex-row gap-4">
                 <Button
                   className="bg-[#00BFA5] hover:bg-[#00A895] text-white px-8 py-6 text-lg font-semibold rounded-lg transition-all duration-200"
-                  onClick={() => window.open('https://innovation-challenge-2026.devpost.com/', '_blank')}
+                  onClick={() => window.open('https://forms.gle/ZWeHuWhNrvVq2MGM6', '_blank')}
                 >
                   Register Now
                 </Button>


### PR DESCRIPTION
- Add scroll-margin-top to hero section to account for sticky navbar
- Increase top padding on mobile to prevent logo from being hidden
- Add useEffect to ensure page starts at top on initial load/reload
- Logo now properly visible below navbar on mobile devices